### PR TITLE
Port to C++/boost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
-pimachine: src/pimachine.c
-	gcc -Wall -Wextra src/pimachine.c -g -lgmp -o pimachine -O2
+pimachine: src/pimachine.cc
+	g++ -Wall -Wextra src/pimachine.cc -g -lgmp -o pimachine -O2

--- a/src/pimachine.cc
+++ b/src/pimachine.cc
@@ -12,25 +12,22 @@ typedef struct {
 	mpz_int d;
 } mpz_frac;
 
-void addFracArray(mpz_frac *rop, const mpz_frac arr[], unsigned long len) {
-	// Store the first numerator of arr into rop to use as initial value
-	rop->d = arr[0].d;
-
+void addFracArray(mpz_frac &rop, const mpz_frac arr[], unsigned long len) {
 	// Find LCM of fraction array and store it as the denomenator
-	for (unsigned long i = 1; i < len; i++) {
-		rop->d = lcm(rop->d, arr[i].d);
+	for (unsigned long i = 0; i < len; i++) {
+		rop.d = lcm(rop.d, arr[i].d);
 	}
 
 	/* Scale the numerator of each fraction to the new denomenator
 	 * and sum it into the new numerator */
 	for (unsigned long i = 0; i < len; i++) {
-		mpz_int multiple = rop->d / arr[i].d;
+		mpz_int multiple = rop.d / arr[i].d;
 		mpz_int num = multiple * arr[i].n;
-		rop->n += num;
+		rop.n += num;
 	}
 }
 
-void calcSeries(mpz_frac *rop, unsigned long n) {
+void calcSeries(mpz_frac &rop, unsigned long n) {
 	mpz_frac facts[n];
 
 	// Initialize sequence variables with zero values
@@ -41,8 +38,8 @@ void calcSeries(mpz_frac *rop, unsigned long n) {
 	mpz_int k = -6;
 
 	// Initialize iteration and rop variable
-	facts[0].n = l;
-	facts[0].d = x;
+	rop.n = facts[0].n = l;
+	rop.d = facts[0].d = x;
 
 	for (unsigned long q = 1; q < n; q++) {
 		// Calculate k
@@ -61,12 +58,8 @@ void calcSeries(mpz_frac *rop, unsigned long n) {
 	}
 
 	// Sum all of the generated fractions into rop.
-	if (n > 1) {
+	if (n > 1)
 		addFracArray(rop, facts, n);
-	} else {
-		rop->n = facts[0].n;
-		rop->d = facts[0].d;
-	}
 }
 
 // WARNING: this returns an malloc'd string! You should probably free it later.
@@ -85,7 +78,7 @@ char *calcPi(unsigned long digits) {
 	c *= 426880;
 
 	// Solve for pi
-	calcSeries(&sum, iterations);
+	calcSeries(sum, iterations);
 	invSum = (mpf_float) sum.d / sum.n;
 	pi = invSum * c;
 

--- a/src/pimachine.cc
+++ b/src/pimachine.cc
@@ -1,94 +1,96 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <gmp.h>
+#include <cstdio>
+#include <cstdlib>
+#include <boost/multiprecision/gmp.hpp>
 
 #define DIGITS_PER_ITERATION 14.1816474627254776555
 #define BITS_PER_DIGIT 3.32192809488736234789 // log2(10)
 
+using namespace boost::multiprecision;
+
 typedef struct {
-	mpz_t n;
-	mpz_t d;
+	mpz_int n;
+	mpz_int d;
 } mpz_frac;
 
 void addFracArray(mpz_frac *rop, const mpz_frac arr[], unsigned long len) {
-	mpz_t multiple, num;
-	mpz_inits(multiple, num, NULL);
+	mpz_int multiple, num;
+	//mpz_inits(multiple, num, NULL);
 
 	// Store the first numerator of arr into rop to use as initial value
-	mpz_set(rop->d, arr[0].d);
+	rop->d = arr[0].d;
 
 	// Find LCM of fraction array and store it as the denomenator
 	for (unsigned long i = 1; i < len; i++) {
-		mpz_lcm(rop->d, rop->d, arr[i].d);
+		rop->d = lcm(rop->d, arr[i].d);
 	}
 
 	/* Scale the numerator of each fraction to the new denomenator
 	 * and sum it into the new numerator */
 	for (unsigned long i = 0; i < len; i++) {
-		mpz_div(multiple, rop->d, arr[i].d);
-		mpz_mul(num, multiple, arr[i].n);
-		mpz_add(rop->n, rop->n, num);
+		multiple = rop->d / arr[i].d;
+		num = multiple * arr[i].n;
+		rop->n *= num;
 	}
 
-	mpz_clears(multiple, num, NULL);
+	//mpz_clears(multiple, num, NULL);
 }
 
 void calcSeries(mpz_frac *rop, unsigned long n) {
-	mpz_t mnum, mden, l, x, k, m1, m2;
+	mpz_int mnum, mden, l, x, k, m1, m2;
 	mpz_frac facts[n];
 
 	// Initialize the mpz_frac array
-	for (unsigned long i = 0; i < n; i++)
-		mpz_inits(facts[i].n, facts[i].d, NULL);
+	//for (unsigned long i = 0; i < n; i++)
+		//mpz_inits(facts[i].n, facts[i].d, NULL);
 
 	// Initialize variables used in sum
-	mpz_inits(m1, m2, NULL);
+	//mpz_inits(m1, m2, NULL);
 
 	// Initialize sequence variables with zero values
-	mpz_init_set_si(mnum, 1);
-	mpz_init_set_si(mden, 1);
-	mpz_init_set_si(l, 13591409);
-	mpz_init_set_si(x, 1);
-	mpz_init_set_si(k, -6);
+	mnum = 1;
+	mden = 1;
+	l = 13591409;
+	x = 1;
+	k = -6;
 
 	// Initialize iteration and rop variable
-	mpz_set(facts[0].n, l);
-	mpz_set(facts[0].d, x);
+	facts[0].n = l;
+	facts[0].d = x;
 
 	for (unsigned long q = 1; q < n; q++) {
 		// Calculate k
-		mpz_add_ui(k, k, 12);
+		k += 12;
 		// Calculate m
-		mpz_pow_ui(m1, k, 3);
-		mpz_mul_ui(m2, k, 16);
-		mpz_sub(m1, m1, m2);
-		mpz_ui_pow_ui(m2, q, 3);
-		mpz_mul(mnum, mnum, m1);
-		mpz_mul(mden, mden, m2);
+		m1 = pow(k, 3);
+		m2 = k * 16;
+		m1 -= m2;
+		m2 = q * q * q;
+		mnum *= m1;
+		mden *= m2;
 		// Calculate l
-		mpz_add_ui(l, l, 545140134);
+		l += 545140134;
 		// Calculate x
-		mpz_mul_si(x, x, -262537412640768000L);
+		x *= -262537412640768000L;
 
 		// Derive sequence from m, l, x
-		mpz_mul(facts[q].n, l, mnum);
-		mpz_mul(facts[q].d, x, mden);
+		facts[q].n = l * mnum;
+		facts[q].d = x * mden;
 	}
 
 	// Sum all of the generated fractions into rop.
 	if (n > 1) {
 		addFracArray(rop, facts, n);
 	} else {
-		mpz_set(rop->n, facts[0].n);
-		mpz_set(rop->d, facts[0].d);
+		rop->n = facts[0].n;
+		rop->d = facts[0].d;
 	}
 
 	// Free the mpz_frac array
-	for (unsigned long i = 0; i < n; i++)
-		mpz_clears(facts[i].n, facts[i].d, NULL);
+	//for (unsigned long i = 0; i < n; i++)
+		//mpz_clears(facts[i].n, facts[i].d, NULL);
 
 	// Free all of our variables
-	mpz_clears(mnum, mden, l, x, k, m1, m2, NULL);
+	//mpz_clears(mnum, mden, l, x, k, m1, m2, NULL);
 }
 
 // WARNING: this returns an malloc'd string! You should probably free it later.
@@ -98,27 +100,29 @@ char *calcPi(unsigned long digits) {
 	unsigned long iterations = digits / DIGITS_PER_ITERATION + 1;
 	mpf_set_default_prec(precisionBits);
 
-	mpf_t c, pi, sumnf, sumdf, invSum;
+	mpf_float c, pi, sumnf, sumdf, invSum;
 	mpz_frac sum;
 	mp_exp_t exp;
-	mpf_inits(c, pi, sumnf, sumdf, invSum, NULL);
-	mpz_inits(sum.n, sum.d, NULL);
+	//mpf_inits(c, pi, sumnf, sumdf, invSum, NULL);
+	//mpz_inits(sum.n, sum.d, NULL);
 
 	// Calculate constant C
-	mpf_sqrt_ui(c, 10005);
-	mpf_mul_ui(c, c, 426880);
+	c = sqrt(10005);
+	c *= 426880;
 
 	// Solve for pi
 	calcSeries(&sum, iterations);
-	mpf_set_z(sumnf, sum.n);
-	mpf_set_z(sumdf, sum.d);
-	mpf_div(invSum, sumdf, sumnf);
-	mpf_mul(pi, invSum, c);
+	//mpf_set_z(sumnf, sum.n.backend().data());
+	//mpf_set_z(sumdf, sum.d.backend().data());
+	sumnf = (mpf_float) sum.n;
+	sumdf = (mpf_float) sum.d;
+	invSum = sumdf / sumnf;
+	pi = invSum * c;
 
 	// Generate string and free variables
-	char *output = mpf_get_str(NULL, &exp, 10, digits, pi);
-	mpf_clears(c, pi, sumnf, sumdf, invSum, NULL);
-	mpz_clears(sum.n, sum.d, NULL);
+	char *output = mpf_get_str(NULL, &exp, 10, digits, pi.backend().data());
+	//mpf_clears(c, pi, sumnf, sumdf, invSum, NULL);
+	//mpz_clears(sum.n, sum.d, NULL);
 	return output;
 }
 

--- a/src/pimachine.cc
+++ b/src/pimachine.cc
@@ -13,9 +13,6 @@ typedef struct {
 } mpz_frac;
 
 void addFracArray(mpz_frac *rop, const mpz_frac arr[], unsigned long len) {
-	mpz_int multiple, num;
-	//mpz_inits(multiple, num, NULL);
-
 	// Store the first numerator of arr into rop to use as initial value
 	rop->d = arr[0].d;
 
@@ -27,31 +24,21 @@ void addFracArray(mpz_frac *rop, const mpz_frac arr[], unsigned long len) {
 	/* Scale the numerator of each fraction to the new denomenator
 	 * and sum it into the new numerator */
 	for (unsigned long i = 0; i < len; i++) {
-		multiple = rop->d / arr[i].d;
-		num = multiple * arr[i].n;
+		mpz_int multiple = rop->d / arr[i].d;
+		mpz_int num = multiple * arr[i].n;
 		rop->n += num;
 	}
-
-	//mpz_clears(multiple, num, NULL);
 }
 
 void calcSeries(mpz_frac *rop, unsigned long n) {
-	mpz_int mnum, mden, l, x, k, m1, m2;
 	mpz_frac facts[n];
 
-	// Initialize the mpz_frac array
-	//for (unsigned long i = 0; i < n; i++)
-		//mpz_inits(facts[i].n, facts[i].d, NULL);
-
-	// Initialize variables used in sum
-	//mpz_inits(m1, m2, NULL);
-
 	// Initialize sequence variables with zero values
-	mnum = 1;
-	mden = 1;
-	l = 13591409;
-	x = 1;
-	k = -6;
+	mpz_int mnum = 1;
+	mpz_int mden = 1;
+	mpz_int l = 13591409;
+	mpz_int x = 1;
+	mpz_int k = -6;
 
 	// Initialize iteration and rop variable
 	facts[0].n = l;
@@ -61,12 +48,8 @@ void calcSeries(mpz_frac *rop, unsigned long n) {
 		// Calculate k
 		k += 12;
 		// Calculate m
-		m1 = pow(k, 3);
-		m2 = k * 16;
-		m1 -= m2;
-		m2 = q * q * q;
-		mnum *= m1;
-		mden *= m2;
+		mnum *= pow(k, 3) - (k * 16);
+		mden *= q * q * q;
 		// Calculate l
 		l += 545140134;
 		// Calculate x
@@ -84,13 +67,6 @@ void calcSeries(mpz_frac *rop, unsigned long n) {
 		rop->n = facts[0].n;
 		rop->d = facts[0].d;
 	}
-
-	// Free the mpz_frac array
-	//for (unsigned long i = 0; i < n; i++)
-		//mpz_clears(facts[i].n, facts[i].d, NULL);
-
-	// Free all of our variables
-	//mpz_clears(mnum, mden, l, x, k, m1, m2, NULL);
 }
 
 // WARNING: this returns an malloc'd string! You should probably free it later.
@@ -100,29 +76,21 @@ char *calcPi(unsigned long digits) {
 	unsigned long iterations = digits / DIGITS_PER_ITERATION + 1;
 	mpf_float::default_precision(precisionBits);
 
-	mpf_float c, pi, sumnf, sumdf, invSum;
+	mpf_float pi, invSum;
 	mpz_frac sum;
 	mp_exp_t exp;
-	//mpf_inits(c, pi, sumnf, sumdf, invSum, NULL);
-	//mpz_inits(sum.n, sum.d, NULL);
 
 	// Calculate constant C
-	c = sqrt(10005);
+	mpf_float c = sqrt(10005);
 	c *= 426880;
 
 	// Solve for pi
 	calcSeries(&sum, iterations);
-	//mpf_set_z(sumnf, sum.n.backend().data());
-	//mpf_set_z(sumdf, sum.d.backend().data());
-	sumnf = (mpf_float) sum.n;
-	sumdf = (mpf_float) sum.d;
-	invSum = sumdf / sumnf;
+	invSum = (mpf_float) sum.d / sum.n;
 	pi = invSum * c;
 
 	// Generate string and free variables
 	char *output = mpf_get_str(NULL, &exp, 10, digits, pi.backend().data());
-	//mpf_clears(c, pi, sumnf, sumdf, invSum, NULL);
-	//mpz_clears(sum.n, sum.d, NULL);
 	return output;
 }
 

--- a/src/pimachine.cc
+++ b/src/pimachine.cc
@@ -29,7 +29,7 @@ void addFracArray(mpz_frac *rop, const mpz_frac arr[], unsigned long len) {
 	for (unsigned long i = 0; i < len; i++) {
 		multiple = rop->d / arr[i].d;
 		num = multiple * arr[i].n;
-		rop->n *= num;
+		rop->n += num;
 	}
 
 	//mpz_clears(multiple, num, NULL);
@@ -98,7 +98,7 @@ char *calcPi(unsigned long digits) {
 	// Set precision of our float.
 	unsigned long precisionBits = digits * BITS_PER_DIGIT + 1;
 	unsigned long iterations = digits / DIGITS_PER_ITERATION + 1;
-	mpf_set_default_prec(precisionBits);
+	mpf_float::default_precision(precisionBits);
 
 	mpf_float c, pi, sumnf, sumdf, invSum;
 	mpz_frac sum;


### PR DESCRIPTION
I figured out that the square root operator does, in fact, work under boost
so we are using C++ now because operator overloading makes this 15x more
readable.

﻿- Port pimachine.c to C++
- Update Makefile
- [pimachine.cc] Fix fraction addition, properly set floating point precision
- [pimachine.cc] Use less variables
- [pimachine.cc] Pass by reference instead of using pointers
